### PR TITLE
Event firing fix

### DIFF
--- a/WebFrontend/Scripts/models/model.chat.js
+++ b/WebFrontend/Scripts/models/model.chat.js
@@ -53,8 +53,8 @@
         parse_msgs: function (data) {
             if (data.length > 0) {
                 data = PBF.lib.parse_chat_messages(data);
-                var msgs = { all_msgs: data.content, update_msgs: true };
-                this.set(msgs);
+                this.set({ all_msgs: data.content });
+                this.set({update_msgs:true});
             }
         },
 

--- a/WebFrontend/Views/Shared/_Layout.cshtml
+++ b/WebFrontend/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width" />
-        <title>@ViewBag.Title</title>
+        <title>GSWAT - Brought to you by Pure Battlefield</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         @Styles.Render("~/Content/themes/base/jquery-ui-1.9.2.custom.min.css")
         @Styles.Render("~/Content/themes/base/CSS/modern.css")


### PR DESCRIPTION
Resolves issue #53, was due to the way backbone handles setting a model's attributes, causing it to not trigger the correct change event. Separating the attribute setting ensures proper event firing.
